### PR TITLE
Add DomainMetadata Entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -16,7 +16,14 @@ type Domain @entity {
   name: String
   colonyAddress: String
   metadata: String
-  metadataHistory: [String!]!
+  metadataHistory: [DomainMetadata!]! @derivedFrom(field: "domain")
+}
+
+type DomainMetadata @entity {
+  id: ID! # colonyAddress_domainId_transactionHash_logId
+  domain: Domain!
+  transaction: Transaction!
+  metadata: String
 }
 
 type Payment @entity {

--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -29,7 +29,7 @@ export function handleDomainAdded(event: DomainAdded): void {
   // event.transaction.input.toHexString()
   // And extract the parent that way. But it causes a memory-access out-of-bounds error which
   // isn't really a good sign...
-  domain.parent = event.address.toHex() + '_1'
+  domain.parent = event.address.toHex() + '_domain_1'
   domain.name = "Domain #" + event.params.domainId.toString()
   domain.colonyAddress = event.address.toHex()
   domain.save()

--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -33,6 +33,7 @@ export function handleDomainAdded(event: DomainAdded): void {
   domain.name = "Domain #" + event.params.domainId.toString()
   if (event.params.domainId.toString() == '1') {
     domain.name = "Root"
+    domain.parent = null
   }
   domain.colonyAddress = event.address.toHex()
   domain.save()

--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -1,10 +1,23 @@
 import { log, Address } from '@graphprotocol/graph-ts'
 
-import { IColony, DomainAdded, PaymentAdded, PaymentPayoutSet, ColonyMetadata, TokensMinted } from '../../generated/templates/Colony/IColony'
+import {
+  IColony,
+  DomainAdded,
+  DomainMetadata,
+  PaymentAdded,
+  PaymentPayoutSet,
+  ColonyMetadata,
+  TokensMinted,
+} from '../../generated/templates/Colony/IColony'
 
-import { Colony, Domain, Payment, FundingPotPayout, FundingPot } from '../../generated/schema'
-
-import { OneTxPayment } from '../../generated/schema'
+import {
+  Colony,
+  Domain,
+  DomainMetadata as DomainMetadataInstance,
+  Payment,
+  FundingPotPayout,
+  FundingPot,
+} from '../../generated/schema'
 
 import { handleEvent } from './event'
 import { createToken } from './token'
@@ -20,6 +33,27 @@ export function handleDomainAdded(event: DomainAdded): void {
   domain.name = "Domain #" + event.params.domainId.toString()
   domain.colonyAddress = event.address.toHex()
   domain.save()
+}
+
+export function handleDomainMetadata(event: DomainMetadata): void {
+  let metadata = event.params.metadata.toString()
+  let domain = new Domain(event.address.toHex() + '_domain_' + event.params.domainId.toString())
+  domain.metadata = metadata
+
+  let metadataHistory = new DomainMetadataInstance(
+    event.address.toHex() +
+    '_domain_' + event.params.domainId.toString() +
+    '_transaction_' + event.transaction.hash.toHexString() +
+    '_log_' + event.logIndex.toString(),
+  )
+  metadataHistory.transaction = event.transaction.hash.toHexString()
+  metadataHistory.domain = domain.id
+  metadataHistory.metadata = metadata
+
+  metadataHistory.save()
+  domain.save()
+
+  handleEvent("DomainMetadata(address,uint256,string)", event, event.address)
 }
 
 export function handlePaymentPayoutSet(event: PaymentPayoutSet): void{

--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -49,6 +49,7 @@ export function handleDomainMetadata(event: DomainMetadata): void {
   let metadataHistory = new DomainMetadataInstance(
     event.address.toHex() +
     '_domain_' + event.params.domainId.toString() +
+    '_metadata_' + metadata +
     '_transaction_' + event.transaction.hash.toHexString() +
     '_log_' + event.logIndex.toString(),
   )

--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -31,6 +31,9 @@ export function handleDomainAdded(event: DomainAdded): void {
   // isn't really a good sign...
   domain.parent = event.address.toHex() + '_domain_1'
   domain.name = "Domain #" + event.params.domainId.toString()
+  if (event.params.domainId.toString() == '1') {
+    domain.name = "Root"
+  }
   domain.colonyAddress = event.address.toHex()
   domain.save()
 }

--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -37,6 +37,8 @@ export function handleDomainAdded(event: DomainAdded): void {
   }
   domain.colonyAddress = event.address.toHex()
   domain.save()
+
+  handleEvent('DomainAdded(address,uint256)', event, event.address);
 }
 
 export function handleDomainMetadata(event: DomainMetadata): void {

--- a/src/mappings/colonyNetwork.ts
+++ b/src/mappings/colonyNetwork.ts
@@ -16,7 +16,6 @@ export function handleColonyAdded(event: ColonyAdded): void {
   let rootDomain = new Domain(event.params.colonyAddress.toHex() + '_domain_1')
   rootDomain.domainChainId = new BigInt(1)
   rootDomain.metadata = ""
-  rootDomain.metadataHistory = []
   rootDomain.save()
 
   let colony = Colony.load(event.params.colonyAddress.toHex())

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     name: ColonyNetwork
     network: mainnet
     source:
-      address: '0x2874A320876791067c07226b03A7c954e127a79C'
+      address: '0x0000000000000000000000000000000000000000'
       abi: IColonyNetwork
     mapping:
       kind: ethereum/events
@@ -82,6 +82,8 @@ templates:
       eventHandlers:
         - event: 'DomainAdded(address,uint256)'
           handler: handleDomainAdded
+        - event: 'DomainMetadata(address,indexed uint256,string)'
+          handler: handleDomainMetadata
         - event: 'PaymentAdded(address,uint256)'
           handler: handlePaymentAdded
         - event: 'PaymentPayoutSet(address,indexed uint256,address,uint256)'


### PR DESCRIPTION
This PR adds in the `DomainMetadata` entity which serves to fetch the domain metadata (ipfs hash) history for a specific domain.