### PR TITLE
Add `funds moved` to subgraph

### DIFF
--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -42,6 +42,7 @@ import {
   PaymentRecipientSet,
   PaymentFinalized,
   TokensBurned,
+  ColonyFundsMovedBetweenFundingPots,
 } from '../../generated/templates/Colony/IColony'
 
 import {
@@ -329,4 +330,6 @@ export function handleTokensBurned(event: TokensBurned): void {
   handleEvent("TokensBurned(address,address,uint256)", event, event.address)
 }
 
-
+export function handleFundsMovedBetweenFundingPots(event: ColonyFundsMovedBetweenFundingPots): void {
+  handleEvent("ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", event, event.address)
+}

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -188,3 +188,7 @@ templates:
           handler: handlePaymentFinalized
         - event: 'TokensBurned(address,address,uint256)'
           handler: handleTokensBurned
+        - event: 'TokensMinted(address,address,uint256)'
+          handler: handleTokensMinted
+        - event: 'ColonyFundsMovedBetweenFundingPots(address,indexed uint256,indexed uint256,uint256,address)'
+          handler: handleFundsMovedBetweenFundingPots

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -188,7 +188,5 @@ templates:
           handler: handlePaymentFinalized
         - event: 'TokensBurned(address,address,uint256)'
           handler: handleTokensBurned
-        - event: 'TokensMinted(address,address,uint256)'
-          handler: handleTokensMinted
         - event: 'ColonyFundsMovedBetweenFundingPots(address,indexed uint256,indexed uint256,uint256,address)'
           handler: handleFundsMovedBetweenFundingPots


### PR DESCRIPTION
Create and wire up "Move Funds" actions Subgraph queries - subgraph part.

Corresponding PR for `colonyDapp` is `Wire up 'Move Funds' action query #2356`.