### PR TITLE
Handle RecoveryModeEntered event

### DIFF
--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -46,6 +46,7 @@ import {
   ColonyRoleSet,
   ColonyUpgraded,
   ColonyUpgraded1 as HistoricColonyUpgraded,
+  RecoveryModeEntered,
 } from '../../generated/templates/Colony/IColony'
 
 import {
@@ -347,4 +348,8 @@ export function handleColonyUpgraded(event: ColonyUpgraded): void {
 
 export function handleHistoricColonyUpgraded(event: HistoricColonyUpgraded): void {
   handleEvent("ColonyUpgraded(uint256,uint256)", event, event.address)
+}
+
+export function handleRecoveryModeEntered(event: RecoveryModeEntered): void {
+  handleEvent("RecoveryModeEntered(address)", event, event.address)
 }

--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -47,6 +47,9 @@ import {
   ColonyUpgraded,
   ColonyUpgraded1 as HistoricColonyUpgraded,
   RecoveryModeEntered,
+  RecoveryModeExitApproved,
+  RecoveryModeExited,
+  RecoveryStorageSlotSet,
 } from '../../generated/templates/Colony/IColony'
 
 import {
@@ -352,4 +355,16 @@ export function handleHistoricColonyUpgraded(event: HistoricColonyUpgraded): voi
 
 export function handleRecoveryModeEntered(event: RecoveryModeEntered): void {
   handleEvent("RecoveryModeEntered(address)", event, event.address)
+}
+
+export function handleRecoveryModeExitApproved(event: RecoveryModeExitApproved): void {
+  handleEvent("RecoveryModeExitApproved(address)", event, event.address)
+}
+
+export function handleRecoveryModeExited(event: RecoveryModeExited): void {
+  handleEvent("RecoveryModeExited(address)", event, event.address)
+}
+
+export function handleRecoveryStorageSlotSet(event: RecoveryStorageSlotSet): void {
+  handleEvent("RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)", event, event.address)
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -199,6 +199,8 @@ templates:
           handler: handlePaymentFinalized
         - event: 'TokensBurned(address,address,uint256)'
           handler: handleTokensBurned
+        - event: RecoveryModeEntered(address)
+          handler: handleRecoveryModeEntered
         - event: >-
             ColonyFundsMovedBetweenFundingPots(address,indexed uint256,indexed
             uint256,uint256,address)

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -201,6 +201,12 @@ templates:
           handler: handleTokensBurned
         - event: RecoveryModeEntered(address)
           handler: handleRecoveryModeEntered
+        - event: RecoveryModeExitApproved(address)
+          handler: handleRecoveryModeExitApproved
+        - event: RecoveryModeExited(address)
+          handler: handleRecoveryModeExited
+        - event: 'RecoveryStorageSlotSet(address,uint256,bytes32,bytes32)'
+          handler: handleRecoveryStorageSlotSet
         - event: >-
             ColonyFundsMovedBetweenFundingPots(address,indexed uint256,indexed
             uint256,uint256,address)


### PR DESCRIPTION
Just as it says on the tin, this PR adds the small feature of handling the `RecoveryModeEntered` event so that it can be surfaced as a Dapp action