### PR TITLE
Handle Extensions Events

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -7,6 +7,7 @@ type Colony @entity {
   domains: [Domain!]!
   metadata: String
   metadataHistory: [ColonyMetadata!]! @derivedFrom(field: "colony")
+  extensions: [ColonyExtension!]
 }
 
 type ColonyMetadata @entity {
@@ -91,4 +92,11 @@ type Event @entity {
   associatedColony: Colony
   name: String
   args: String
+}
+
+type ColonyExtension @entity {
+  id: ID! # Address
+  colony: Colony!
+  hash: String
+  installed: Boolean
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -95,8 +95,8 @@ type Event @entity {
 }
 
 type ColonyExtension @entity {
-  id: ID! # Address
+  id: ID! # colonyAddress_extensionId_transactionHash_logId
+  address: String!
   colony: Colony!
-  hash: String
-  installed: Boolean
+  hash: String!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,7 +7,7 @@ type Colony @entity {
   domains: [Domain!]!
   metadata: String
   metadataHistory: [ColonyMetadata!]! @derivedFrom(field: "colony")
-  extensions: [ColonyExtension!]
+  extensions: [ColonyExtension!] @derivedFrom(field: "colony")
 }
 
 type ColonyMetadata @entity {

--- a/src/mappings/coinMachine.ts
+++ b/src/mappings/coinMachine.ts
@@ -1,16 +1,18 @@
-import { BigInt, crypto, ByteArray, Bytes } from '@graphprotocol/graph-ts'
-import { log } from '@graphprotocol/graph-ts'
-
 import {
+  ExtensionInitialised,
   TokensBought,
   PeriodUpdated,
-} from '../../generated/templates/CoinMachine/CoinMachine'
-
-import {
   CoinMachine as CoinMachineContract
 } from '../../generated/templates/CoinMachine/CoinMachine'
 
 import { handleEvent } from './event'
+
+export function handleExtensionInitialised(event: ExtensionInitialised): void {
+  let extension = CoinMachineContract.bind(event.address);
+  let colony = extension.getColony();
+
+  handleEvent("ExtensionInitialised()", event, colony)
+}
 
 export function handleTokensBought(event: TokensBought): void {
   let extension = CoinMachineContract.bind(event.address);

--- a/src/mappings/colonyNetwork.ts
+++ b/src/mappings/colonyNetwork.ts
@@ -7,6 +7,9 @@ import {
   ColonyAdded,
   ColonyLabelRegistered,
   ExtensionInstalled,
+  ExtensionUninstalled,
+  ExtensionDeprecated,
+  ExtensionUpgraded,
 } from '../../generated/ColonyNetwork/IColonyNetwork'
 
 import { handleEvent } from './event'
@@ -89,8 +92,6 @@ export function handleExtensionInstalled(event: ExtensionInstalled): void {
     log.info("Adding extension at address {}", [extensionAddress.toHexString()]);
 
     OneTxPaymentTemplate.create(extensionAddress)
-
-    handleEvent("ExtensionInstalled(bytes32,address,version)", event, event.params.colony)
   }
 
   if (event.params.extensionId.toHexString() == COIN_MACHINE) {
@@ -101,4 +102,18 @@ export function handleExtensionInstalled(event: ExtensionInstalled): void {
 
     CoinMachineTemplate.create(extensionAddress)
   }
+
+  handleEvent("ExtensionInstalled(bytes32,address,version)", event, event.params.colony)
+}
+
+export function handleExtensionUninstalled(event: ExtensionUninstalled): void {
+  handleEvent("ExtensionUninstalled(bytes32,address)", event, event.params.colony)
+}
+
+export function handleExtensionDeprecated(event: ExtensionDeprecated): void {
+  handleEvent("ExtensionDeprecated(bytes32,address,bool)", event, event.params.colony)
+}
+
+export function handleExtensionUpgraded(event: ExtensionUpgraded): void {
+  handleEvent("ExtensionUpgraded(bytes32,address,uint256)", event, event.params.colony)
 }

--- a/src/mappings/colonyNetwork.ts
+++ b/src/mappings/colonyNetwork.ts
@@ -90,7 +90,7 @@ export function handleExtensionInstalled(event: ExtensionInstalled): void {
 
     OneTxPaymentTemplate.create(extensionAddress)
 
-    handleEvent("ExtensionInstalled(bytes32,address,version)", event, event.address)
+    handleEvent("ExtensionInstalled(bytes32,address,version)", event, event.params.colony)
   }
 
   if (event.params.extensionId.toHexString() == COIN_MACHINE) {

--- a/src/mappings/colonyNetwork.ts
+++ b/src/mappings/colonyNetwork.ts
@@ -85,14 +85,19 @@ export function handleExtensionInstalled(event: ExtensionInstalled): void {
   let ONE_TX_PAYMENT = crypto.keccak256(ByteArray.fromUTF8("OneTxPayment")).toHexString()
   let COIN_MACHINE = crypto.keccak256(ByteArray.fromUTF8("CoinMachine")).toHexString()
 
-  let cn = IColonyNetwork.bind(event.address);
+  let cn = IColonyNetwork.bind(event.address)
   let colony = Colony.load(event.params.colony.toHexString())
   let extensionAddress = cn.getExtensionInstallation(event.params.extensionId, event.params.colony)
 
-  let extension = new ColonyExtension(extensionAddress.toHexString())
+  let extension = new ColonyExtension(
+    colony.id.toString() +
+    '_extension_' + event.params.extensionId.toHexString() +
+    '_transaction_' + event.transaction.hash.toHexString() +
+    '_log_' + event.logIndex.toString(),
+  )
+  extension.address = extensionAddress.toHexString()
   extension.hash = event.params.extensionId.toHexString()
   extension.colony = colony.id
-  extension.installed = true;
 
   if (event.params.extensionId.toHexString() == ONE_TX_PAYMENT) {
     OneTxPaymentTemplate.create(extensionAddress)

--- a/src/mappings/oneTxPayment.ts
+++ b/src/mappings/oneTxPayment.ts
@@ -1,13 +1,21 @@
-import { BigInt, crypto, ByteArray, Bytes } from '@graphprotocol/graph-ts'
-import { log } from '@graphprotocol/graph-ts'
+import { BigInt } from '@graphprotocol/graph-ts'
 
-import { OneTxPaymentMade } from '../../generated/templates/OneTxPayment/OneTxPayment'
+import {
+  OneTxPaymentMade,
+  ExtensionInitialised,
+  OneTxPayment as OneTxPaymentContract,
+} from '../../generated/templates/OneTxPayment/OneTxPayment'
 
-import { OneTxPayment, Transaction, Block } from '../../generated/schema'
-
-import { OneTxPayment as OneTxPaymentContract } from '../../generated/templates/OneTxPayment/OneTxPayment'
+import { OneTxPayment } from '../../generated/schema'
 
 import { handleEvent } from './event'
+
+export function handleExtensionInitialised(event: ExtensionInitialised): void {
+  let extension = OneTxPaymentContract.bind(event.address);
+  let colony = extension.getColony();
+
+  handleEvent("ExtensionInitialised()", event, colony)
+}
 
 export function handleOneTxPaymentMade(event: OneTxPaymentMade): void {
   let extension = OneTxPaymentContract.bind(event.address);
@@ -28,6 +36,4 @@ export function handleOneTxPaymentMade(event: OneTxPaymentMade): void {
   otxp.save()
 
   handleEvent("OneTxPaymentMade(address,uint256,uint256)", event, colony)
-
 }
-

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -70,6 +70,8 @@ templates:
       eventHandlers:
         - event: 'OneTxPaymentMade(address,uint256,uint256)'
           handler: handleOneTxPaymentMade
+        - event: ExtensionInitialised()
+          handler: handleExtensionInitialised
   - name: CoinMachine
     kind: ethereum/contract
     network: mainnet
@@ -90,6 +92,8 @@ templates:
           handler: handleTokensBought
         - event: 'PeriodUpdated(uint256,uint256)'
           handler: handlePeriodUpdated
+        - event: ExtensionInitialised()
+          handler: handleExtensionInitialised
   - name: Colony
     kind: ethereum/contract
     network: mainnet

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -28,6 +28,12 @@ dataSources:
           handler: handleColonyLabelRegistered
         - event: 'ExtensionInstalled(indexed bytes32,indexed address,uint256)'
           handler: handleExtensionInstalled
+        - event: 'ExtensionUninstalled(indexed bytes32,indexed address)'
+          handler: handleExtensionUninstalled
+        - event: 'ExtensionDeprecated(indexed bytes32,indexed address,bool)'
+          handler: handleExtensionDeprecated
+        - event: 'ExtensionUpgraded(indexed bytes32,indexed address,uint256)'
+          handler: handleExtensionUpgraded
       file: ./src/mappings/colonyNetwork.ts
 templates:
   - name: Token


### PR DESCRIPTION
This PR adds events handlers for all events related to Extensions:
- ExtensionInstalled
- ExtensionInitialised
- ExtensionDeprecated
- ExtensionUninstalled
- ExtensionUpgraded

Alongside that, we also add a `ColonyExtension` entity that will record all extensions that were installed on the specific colony, and track their addresses, even after the extensions were uninstalled