### PR TITLE
Introduce startBlock parameter to subgraph.yaml

### DIFF
--- a/.github/workflows/deployGoerli.yaml
+++ b/.github/workflows/deployGoerli.yaml
@@ -17,6 +17,8 @@ jobs:
         run: npm i
       - name: Patch subgraph for bad domains
         run: sed -i "s|'colony.joincolony.eth', 'colony.joincolony.eth'|'colony.joincolony.eth', 'colony.joincolony.test'|g" ./src/mappings/colonyNetwork.ts
+      - name: Patch subgraph for start block
+        run: sed -i 's|startBlock: 1|startBlock: 526045|g' ./subgraph.yaml
       - name: Build the graph
         run: npm run build-goerli
         env:

--- a/.github/workflows/deployXdai.yaml
+++ b/.github/workflows/deployXdai.yaml
@@ -17,6 +17,8 @@ jobs:
         run: npm i
       - name: Patch subgraph for bad domains
         run: sed -i "s|'colony.joincolony.eth', 'colony.joincolony.eth'|'colony.joincolony.eth', 'colony.joincolony.colonyxdai'|g" ./src/mappings/colonyNetwork.ts
+      - name: Patch subgraph for start block
+        run: sed -i 's|startBlock: 1|startBlock: 11879715|g' ./subgraph.yaml
       - name: Build the graph
         run: npm run build-xdai
         env:

--- a/.github/workflows/deployXdaiQA.yaml
+++ b/.github/workflows/deployXdaiQA.yaml
@@ -17,6 +17,8 @@ jobs:
         run: npm i
       - name: Patch subgraph for bad domains
         run: sed -i "s|'colony.joincolony.eth', 'colony.joincolony.eth'|'colony.joincolony.eth', 'colony.joincolony.colonyxdai'|g" ./src/mappings/colonyNetwork.ts
+      - name: Patch subgraph for start block
+        run: sed -i 's|startBlock: 1|startBlock: 14540734|g' ./subgraph.yaml
       - name: Build the graph
         run: npm run build-xdai-qa
         env:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -10,6 +10,7 @@ dataSources:
     source:
       address: '0x0000000000000000000000000000000000000000'
       abi: IColonyNetwork
+      startBlock: 1
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4


### PR DESCRIPTION
Taking advantage of the parameter documented [here](https://thegraph.com/docs/define-a-subgraph#the-subgraph-manifest) we are able to make our subgraph deployments go quicker (for now... they will just slow down over time though).

The startblock is 1 by default, so should still work with development environments, it's only changed when we're deploying to a specific network in the GitHub build steps when we know when we made a particular deployment.