### PR TITLE
Add Motion Entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -103,11 +103,12 @@ type ColonyExtension @entity {
 
 type Motion @entity {
   id: ID! # colonyAddress_motion_extensionAddress_motionId
+  extensionAddress: String
   associatedColony: Colony
   transaction: Transaction
   agent: String
   domain: Domain
-  state: Int
-  stake: BigInt
+  currentStake: BigInt
+  requiredStake: BigInt
   escalated: Boolean
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -104,6 +104,7 @@ type ColonyExtension @entity {
 type Motion @entity {
   id: ID! # colonyAddress_motion_extensionAddress_motionId
   fundamentalChainId: BigInt
+  action: String
   extensionAddress: String
   associatedColony: Colony
   transaction: Transaction

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,7 +18,7 @@ type ColonyMetadata @entity {
 }
 
 type Domain @entity {
-  id: ID! # colonyAddress_domainId
+  id: ID! # colonyAddress_domain_domainId
   domainChainId: BigInt!
   parent: Domain
   name: String
@@ -99,4 +99,15 @@ type ColonyExtension @entity {
   address: String!
   colony: Colony!
   hash: String!
+}
+
+type Motion @entity {
+  id: ID! # colonyAddress_motion_extensionAddress_motionId
+  associatedColony: Colony
+  transaction: Transaction
+  agent: String
+  domain: Domain
+  state: Int
+  stake: BigInt
+  escalated: Boolean
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -103,6 +103,7 @@ type ColonyExtension @entity {
 
 type Motion @entity {
   id: ID! # colonyAddress_motion_extensionAddress_motionId
+  fundamentalChainId: BigInt
   extensionAddress: String
   associatedColony: Colony
   transaction: Transaction

--- a/scripts/generateInterfaces.js
+++ b/scripts/generateInterfaces.js
@@ -23,6 +23,7 @@ async function main() {
 		await exec("mv ./colonyNetwork/build/contracts/IColony.json ./interfaces")
 		await exec("mv ./colonyNetwork/build/contracts/OneTxPayment.json ./interfaces")
 		await exec("mv ./colonyNetwork/build/contracts/CoinMachine.json ./interfaces")
+    await exec("mv ./colonyNetwork/build/contracts/VotingReputation.json ./interfaces")
 		console.log("Interfaces extracted")
 	} catch (err) {
 		console.log(err)

--- a/src/mappings/colonyNetwork.ts
+++ b/src/mappings/colonyNetwork.ts
@@ -20,6 +20,7 @@ import {
   Colony as ColonyTemplate,
   OneTxPayment as OneTxPaymentTemplate,
   CoinMachine as CoinMachineTemplate,
+  VotingReputation as VotingReputationTemplate,
 } from '../../generated/templates'
 
 import { createToken } from './token'
@@ -84,6 +85,7 @@ export function handleColonyLabelRegistered(event: ColonyLabelRegistered): void 
 export function handleExtensionInstalled(event: ExtensionInstalled): void {
   let ONE_TX_PAYMENT = crypto.keccak256(ByteArray.fromUTF8("OneTxPayment")).toHexString()
   let COIN_MACHINE = crypto.keccak256(ByteArray.fromUTF8("CoinMachine")).toHexString()
+  let VOTING_REPUTATION = crypto.keccak256(ByteArray.fromUTF8("VotingReputation")).toHexString()
 
   let cn = IColonyNetwork.bind(event.address)
   let colony = Colony.load(event.params.colony.toHexString())
@@ -105,6 +107,10 @@ export function handleExtensionInstalled(event: ExtensionInstalled): void {
 
   if (event.params.extensionId.toHexString() == COIN_MACHINE) {
     CoinMachineTemplate.create(extensionAddress)
+  }
+
+  if (event.params.extensionId.toHexString() == VOTING_REPUTATION) {
+    VotingReputationTemplate.create(extensionAddress)
   }
 
   handleEvent("ExtensionInstalled(bytes32,address,version)", event, event.params.colony)

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -2,6 +2,7 @@ import { BigInt } from '@graphprotocol/graph-ts'
 
 import {
   MotionCreated,
+  MotionStaked,
   ExtensionInitialised,
   VotingReputation as VotingReputationContract
 } from '../../generated/templates/VotingReputation/VotingReputation'
@@ -37,4 +38,19 @@ export function handleMotionCreated(event: MotionCreated): void {
   motion.save()
 
   handleEvent("MotionCreated(uint256,address,uint256)", event, colony)
+}
+
+export function handleMotionStaked(event: MotionStaked): void {
+  let extension = VotingReputationContract.bind(event.address);
+  let colony = extension.getColony();
+
+  let motionId = event.params.motionId;
+  let chainMotion = extension.getMotion(motionId);
+
+  let motion = new Motion(colony.toHexString() + "_motion_" + extension._address.toHexString() + '_' + motionId.toString());
+  motion.currentStake = chainMotion.stakes.pop()
+
+  motion.save()
+
+  handleEvent("MotionStaked(uint256,address,uint256,uint256)", event, colony)
 }

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -1,0 +1,23 @@
+import {
+  MotionCreated,
+  ExtensionInitialised,
+  VotingReputation as VotingReputationContract
+} from '../../generated/templates/VotingReputation/VotingReputation'
+
+import { log } from '@graphprotocol/graph-ts'
+
+import { handleEvent } from './event'
+
+export function handleExtensionInitialised(event: ExtensionInitialised): void {
+  let extension = VotingReputationContract.bind(event.address);
+  let colony = extension.getColony();
+
+  handleEvent("ExtensionInitialised()", event, colony)
+}
+
+export function handleMotionCreated(event: MotionCreated): void {
+  let extension = VotingReputationContract.bind(event.address);
+  let colony = extension.getColony();
+
+  handleEvent("MotionCreated(uint256,address,uint256)", event, colony)
+}

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -27,6 +27,7 @@ export function handleMotionCreated(event: MotionCreated): void {
   let chainMotion = extension.getMotion(motionId);
 
   let motion = new Motion(colony.toHexString() + "_motion_" + extension._address.toHexString() + '_' + motionId.toString());
+  motion.fundamentalChainId = motionId
   motion.associatedColony = colony.toHexString()
   motion.extensionAddress = extension._address.toHexString()
   motion.transaction = event.transaction.hash.toHexString()

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -25,16 +25,18 @@ export function handleMotionCreated(event: MotionCreated): void {
 
   let motionId = event.params.motionId;
   let chainMotion = extension.getMotion(motionId);
+  let totalStakeFraction = extension.getTotalStakeFraction();
 
   let motion = new Motion(colony.toHexString() + "_motion_" + extension._address.toHexString() + '_' + motionId.toString());
   motion.fundamentalChainId = motionId
+  motion.action = chainMotion.action.toHexString()
   motion.associatedColony = colony.toHexString()
   motion.extensionAddress = extension._address.toHexString()
   motion.transaction = event.transaction.hash.toHexString()
   motion.agent = event.params.creator.toHexString()
   motion.domain = colony.toHexString() + '_domain_' + event.params.domainId.toString()
   motion.currentStake = chainMotion.stakes.pop()
-  motion.requiredStake = new BigInt(0)
+  motion.requiredStake = chainMotion.skillRep.times(totalStakeFraction).div(BigInt.fromI32(10).pow(18))
   motion.escalated = chainMotion.escalated
 
   motion.save()

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -3,6 +3,7 @@ import { BigInt } from '@graphprotocol/graph-ts'
 import {
   MotionCreated,
   MotionStaked,
+  MotionEscalated,
   ExtensionInitialised,
   VotingReputation as VotingReputationContract
 } from '../../generated/templates/VotingReputation/VotingReputation'
@@ -53,4 +54,19 @@ export function handleMotionStaked(event: MotionStaked): void {
   motion.save()
 
   handleEvent("MotionStaked(uint256,address,uint256,uint256)", event, colony)
+}
+
+export function handleMotionEscalated(event: MotionEscalated): void {
+  let extension = VotingReputationContract.bind(event.address);
+  let colony = extension.getColony();
+
+  let motionId = event.params.motionId;
+  let chainMotion = extension.getMotion(motionId);
+
+  let motion = new Motion(colony.toHexString() + "_motion_" + extension._address.toHexString() + '_' + motionId.toString());
+  motion.escalated = chainMotion.escalated
+
+  motion.save()
+
+  handleEvent("MotionEscalated(uint256,address,uint256,uint256)", event, colony)
 }

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -1,10 +1,12 @@
+import { log } from '@graphprotocol/graph-ts'
+
 import {
   MotionCreated,
   ExtensionInitialised,
   VotingReputation as VotingReputationContract
 } from '../../generated/templates/VotingReputation/VotingReputation'
 
-import { log } from '@graphprotocol/graph-ts'
+import { Motion } from '../../generated/schema'
 
 import { handleEvent } from './event'
 
@@ -18,6 +20,20 @@ export function handleExtensionInitialised(event: ExtensionInitialised): void {
 export function handleMotionCreated(event: MotionCreated): void {
   let extension = VotingReputationContract.bind(event.address);
   let colony = extension.getColony();
+
+  let motionId = event.params.motionId;
+  let chainMotion = extension.getMotion(motionId);
+
+  let motion = new Motion(colony.toHexString() + "_motion_" + extension._address.toHexString() + '_' + motionId.toString());
+  motion.associatedColony = colony.toHexString()
+  motion.transaction = event.transaction.hash.toHexString()
+  motion.agent = event.params.creator.toHexString()
+  motion.domain = colony.toHexString() + '_domain_' + event.params.domainId.toString()
+  motion.state = extension.getMotionState(motionId)
+  motion.stake = chainMotion.stakes.pop()
+  motion.escalated = chainMotion.escalated
+
+  motion.save()
 
   handleEvent("MotionCreated(uint256,address,uint256)", event, colony)
 }

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -1,4 +1,4 @@
-import { log } from '@graphprotocol/graph-ts'
+import { BigInt } from '@graphprotocol/graph-ts'
 
 import {
   MotionCreated,
@@ -26,11 +26,12 @@ export function handleMotionCreated(event: MotionCreated): void {
 
   let motion = new Motion(colony.toHexString() + "_motion_" + extension._address.toHexString() + '_' + motionId.toString());
   motion.associatedColony = colony.toHexString()
+  motion.extensionAddress = extension._address.toHexString()
   motion.transaction = event.transaction.hash.toHexString()
   motion.agent = event.params.creator.toHexString()
   motion.domain = colony.toHexString() + '_domain_' + event.params.domainId.toString()
-  motion.state = extension.getMotionState(motionId)
-  motion.stake = chainMotion.stakes.pop()
+  motion.currentStake = chainMotion.stakes.pop()
+  motion.requiredStake = new BigInt(0)
   motion.escalated = chainMotion.escalated
 
   motion.save()

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     name: ColonyNetwork
     network: mainnet
     source:
-      address: '0x0000000000000000000000000000000000000000'
+      address: '0x45B17FF6998D4d76A10a32621A71773E3722DA65'
       abi: IColonyNetwork
       startBlock: 1
     mapping:
@@ -93,6 +93,26 @@ templates:
           handler: handleTokensBought
         - event: 'PeriodUpdated(uint256,uint256)'
           handler: handlePeriodUpdated
+        - event: ExtensionInitialised()
+          handler: handleExtensionInitialised
+  - name: VotingReputation
+    kind: ethereum/contract
+    network: mainnet
+    source:
+      abi: VotingReputation
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/votingReputation.ts
+      entities:
+        - VotingReputation
+      abis:
+        - name: VotingReputation
+          file: ./../colonyNetwork/build/contracts/VotingReputation.json
+      eventHandlers:
+        - event: 'MotionCreated(indexed uint256,address,indexed uint256)'
+          handler: handleMotionCreated
         - event: ExtensionInitialised()
           handler: handleExtensionInitialised
   - name: Colony

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -119,6 +119,10 @@ templates:
             MotionStaked(indexed uint256,indexed address,indexed
             uint256,uint256)
           handler: handleMotionStaked
+        - event: >-
+            MotionEscalated(indexed uint256,address,indexed uint256,indexed
+            uint256)
+          handler: handleMotionEscalated
   - name: Colony
     kind: ethereum/contract
     network: mainnet

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     name: ColonyNetwork
     network: mainnet
     source:
-      address: '0x45B17FF6998D4d76A10a32621A71773E3722DA65'
+      address: '0x0000000000000000000000000000000000000000'
       abi: IColonyNetwork
       startBlock: 1
     mapping:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -115,6 +115,10 @@ templates:
           handler: handleMotionCreated
         - event: ExtensionInitialised()
           handler: handleExtensionInitialised
+        - event: >-
+            MotionStaked(indexed uint256,indexed address,indexed
+            uint256,uint256)
+          handler: handleMotionStaked
   - name: Colony
     kind: ethereum/contract
     network: mainnet


### PR DESCRIPTION
This PR adds in the required handlers to be able to fetch events from _Voting Reputation_ extension, as well as creating a new `Motion` entity from the `MotionCreated` events to be queried from the dapp side