### PR TITLE
Update mapping to return stakes array

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -110,7 +110,7 @@ type Motion @entity {
   transaction: Transaction
   agent: String
   domain: Domain
-  currentStake: BigInt
+  stakes: [BigInt!]
   requiredStake: BigInt
   escalated: Boolean
 }

--- a/src/mappings/votingReputation.ts
+++ b/src/mappings/votingReputation.ts
@@ -35,7 +35,7 @@ export function handleMotionCreated(event: MotionCreated): void {
   motion.transaction = event.transaction.hash.toHexString()
   motion.agent = event.params.creator.toHexString()
   motion.domain = colony.toHexString() + '_domain_' + event.params.domainId.toString()
-  motion.currentStake = chainMotion.stakes.pop()
+  motion.stakes = chainMotion.stakes;
   motion.requiredStake = chainMotion.skillRep.times(totalStakeFraction).div(BigInt.fromI32(10).pow(18))
   motion.escalated = chainMotion.escalated
 
@@ -52,7 +52,7 @@ export function handleMotionStaked(event: MotionStaked): void {
   let chainMotion = extension.getMotion(motionId);
 
   let motion = new Motion(colony.toHexString() + "_motion_" + extension._address.toHexString() + '_' + motionId.toString());
-  motion.currentStake = chainMotion.stakes.pop()
+  motion.stakes = chainMotion.stakes;
 
   motion.save()
 


### PR DESCRIPTION
This PR refactor motion entity to return full stakes array instead of just stakes for yay