### PR TITLE
Handle Extension Related Events

### DIFF
--- a/src/mappings/colonyNetwork.ts
+++ b/src/mappings/colonyNetwork.ts
@@ -10,6 +10,7 @@ import {
   ExtensionUninstalled,
   ExtensionDeprecated,
   ExtensionUpgraded,
+  ExtensionAddedToNetwork,
 } from '../../generated/ColonyNetwork/IColonyNetwork'
 
 import { handleEvent } from './event'
@@ -129,4 +130,11 @@ export function handleExtensionDeprecated(event: ExtensionDeprecated): void {
 
 export function handleExtensionUpgraded(event: ExtensionUpgraded): void {
   handleEvent("ExtensionUpgraded(bytes32,address,uint256)", event, event.params.colony)
+}
+
+export function handleExtensionAddedToNetwork(event: ExtensionAddedToNetwork): void {
+  let cn = IColonyNetwork.bind(event.address)
+  let extensionResolver = cn.getExtensionResolver(event.params.extensionId, event.params.version)
+
+  handleEvent("ExtensionAddedToNetwork(bytes32,uint256)", event, extensionResolver)
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -35,6 +35,8 @@ dataSources:
           handler: handleExtensionDeprecated
         - event: 'ExtensionUpgraded(indexed bytes32,indexed address,uint256)'
           handler: handleExtensionUpgraded
+        - event: 'ExtensionAddedToNetwork(indexed bytes32,uint256)'
+          handler: handleExtensionAddedToNetwork
       file: ./src/mappings/colonyNetwork.ts
 templates:
   - name: Token


### PR DESCRIPTION
This PR handles the remaining extension event we emit from the `IColonyNetwork` contract when deploying a new version of an extension to the network

In this PR:
- handle `ExtensionAddedToNetwork(indexed bytes32,uint256)` event