### PR TITLE
Add indexing for TokenUnlocked event

### DIFF
--- a/src/mappings/colony.ts
+++ b/src/mappings/colony.ts
@@ -8,6 +8,7 @@ import {
   PaymentAdded,
   PaymentPayoutSet,
   ColonyMetadata,
+  TokenUnlocked,
   TokensMinted,
   ColonyInitialised,
   ColonyBootstrapped,
@@ -184,6 +185,10 @@ export function handleTaskWorkRatingRevealed(event: TaskWorkRatingRevealed): voi
 
 export function handleTaskFinalized(event: TaskFinalized): void {
   handleEvent("TaskFinalized(address,uint256)", event, event.address)
+}
+
+export function handleTokenUnlocked(event: TokenUnlocked): void {
+  handleEvent("TokenUnlocked()", event, event.address)
 }
 
 export function handleTokensMinted(event: TokensMinted): void {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -235,6 +235,8 @@ templates:
           handler: handleTaskWorkRatingRevealed
         - event: 'TaskFinalized(address,indexed uint256)'
           handler: handleTaskFinalized
+        - event: 'TokenUnlocked()'
+          handler: handleTokenUnlocked
         - event: 'TokensMinted(address,address,uint256)'
           handler: handleTokensMinted
         - event: 'PayoutClaimed(address,indexed uint256,address,uint256)'


### PR DESCRIPTION
### Description

This PR adds the TokenUnlocked event to the SubGraph for indexing.

This has been tested locally, confirming that these updates correctly index the event and the event is queryable without causing any side effects.

![tokenunlock-subgraph-event](https://user-images.githubusercontent.com/33682027/147679438-b490dc6c-fd8e-4c6e-9f88-1521d326cfae.png)

