### PR TITLE
Ability to remove arbitrary Colony Network abi items

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-contract": "solc contracts/Gravity.sol --abi -o abis --overwrite && solc contracts/Gravity.sol --bin -o bin --overwrite",
     "create": "graph create joinColony/subgraph --node https://api.thegraph.com/deploy/",
     "create-local": "graph create joinColony/subgraph --node http://127.0.0.1:8020",
-    "precodegen": "node scripts/setup_config.js && node scripts/append_abis.js",
+    "precodegen": "node scripts/setup_config.js && node scripts/update_abis.js",
     "codegen": "graph codegen",
     "build": "graph build",
     "build-goerli": "sed -i'' -e 's/network: mainnet/network: goerli/g' ./subgraph.yaml && NETWORK_ADDRESS='0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B' node ./scripts/generateInterfaces && NETWORK_ADDRESS='0x79073fc2117dD054FCEdaCad1E7018C9CbE3ec0B' npm run codegen && graph build",

--- a/scripts/removedColonyAbis.json
+++ b/scripts/removedColonyAbis.json
@@ -1,0 +1,71 @@
+[
+  {
+    "inputs":
+      [
+        {
+            "internalType": "uint256",
+            "name": "_id",
+            "type": "uint256"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "_recipientSlots",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "address payable[]",
+            "name": "_recipients",
+            "type": "address[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "_skillIdSlots",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "_skillIds",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "_claimDelaySlots",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "_claimDelays",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "uint256[]",
+            "name": "_payoutModifierSlots",
+            "type": "uint256[]"
+        },
+        {
+            "internalType": "int256[]",
+            "name": "_payoutModifiers",
+            "type": "int256[]"
+        },
+        {
+            "internalType": "address[]",
+            "name": "_payoutTokens",
+            "type": "address[]"
+        },
+        {
+            "internalType": "uint256[][]",
+            "name": "_payoutSlots",
+            "type": "uint256[][]"
+        },
+        {
+            "internalType": "uint256[][]",
+            "name": "_payoutValues",
+            "type": "uint256[][]"
+        }
+      ],
+    "name": "setExpenditureValues",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/scripts/setup_config.js
+++ b/scripts/setup_config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const os = require('os');
 const { readFileSync, writeFileSync, existsSync } = require('fs');
 const yaml = require('js-yaml');
 

--- a/scripts/update_abis.js
+++ b/scripts/update_abis.js
@@ -5,41 +5,63 @@ const ICOLONY_PATH = process.env.CUSTOM_ICOLONY_PATH ? path.resolve(__dirname, p
 const COINMACHINE_PATH = process.env.CUSTOM_COINMACHINE_PATH ? path.resolve(__dirname, process.env.CUSTOM_COINMACHINE_PATH) : path.resolve(__dirname, '..', '..', 'colonyNetwork/build/contracts/CoinMachine.json');
 
 const ADDITIONAL_COLONY_ABIS_PATH = path.resolve(__dirname, './additionalColonyAbis.json');
+const REMOVED_COLONY_ABIS_PATH = path.resolve(__dirname, './removedColonyAbis.json');
 const ADDITIONAL_COINMACHINE_ABIS_PATH = path.resolve(__dirname, './additionalCoinMachineAbis.json');
 
 console.log('interfaces path(s)')
 console.log('Colony:', ICOLONY_PATH)
 console.log('Coin Machine:', COINMACHINE_PATH)
 
+const generateSig = (name, inputs) => `${name}(${inputs.map((parameter) => parameter.type).join(",")})`;
+
 /*
  * Colony
  */
 const IColony = require(ICOLONY_PATH);
 const additionalColonyAbis = require(ADDITIONAL_COLONY_ABIS_PATH);
+const removedColonyAbis = require(REMOVED_COLONY_ABIS_PATH);
 const neededColonyAbis = [];
-const existingColonySigs = IColony.abi.map(({ name, inputs }) => `${name}(${inputs.map((parameter) => parameter.type).join(",")})`);
+const unneededColonyAbis = [];
+const existingColonySigs = IColony.abi.map(({ name, inputs }) => generateSig(name, inputs));
 
 additionalColonyAbis.map((abiEntry) => {
   const { name, inputs } = abiEntry;
-  const signature = `${name}(${inputs.map((parameter) => parameter.type).join(",")})`;
+  const signature = generateSig(name, inputs);
+  // If it doesn't exist, don't add it (this is a sanity check)
   if (existingColonySigs.indexOf(signature) === -1) {
     neededColonyAbis.push(abiEntry);
   }
 });
 
-console.log('Adding following Colony abis')
+removedColonyAbis.map((abiEntry) => {
+  const { name, inputs } = abiEntry;
+  const signature = generateSig(name, inputs);
+  console.log(name, signature);
+  // only attempt to remove it, if it does indeed exist
+  if (existingColonySigs.indexOf(signature) >= 0) {
+    unneededColonyAbis.push(abiEntry);
+  }
+});
+
+console.log('ADDING following Colony abis')
 console.log(neededColonyAbis)
+
+console.log('REMOVING following Colony abis')
+console.log(unneededColonyAbis)
 
 writeFileSync(ICOLONY_PATH, JSON.stringify({
   ...IColony,
   abi: [
     ...IColony.abi,
     ...neededColonyAbis,
-  ],
+  ].filter(({ name, inputs }) => {
+    const currentItemSignature = generateSig(name, inputs);
+    const foundItem = unneededColonyAbis.find(({ name, inputs }) => generateSig(name, inputs) === currentItemSignature);
+    return !foundItem;
+  }),
 }), {
   encoding: "utf8",
 });
-
 
 /*
  * Coin Machine
@@ -47,17 +69,17 @@ writeFileSync(ICOLONY_PATH, JSON.stringify({
 const CoinMachine = require(COINMACHINE_PATH);
 const additionalCoinMachineAbis = require(ADDITIONAL_COINMACHINE_ABIS_PATH);
 const neededCoinMachineAbis = [];
-const existingCoinMachineSigs = CoinMachine.abi.map(({ name, inputs }) => `${name}(${inputs.map((parameter) => parameter.type).join(",")})`);
+const existingCoinMachineSigs = CoinMachine.abi.map(({ name, inputs }) => generateSig(name, inputs));
 
 additionalCoinMachineAbis.map((abiEntry) => {
   const { name, inputs } = abiEntry;
-  const signature = `${name}(${inputs.map((parameter) => parameter.type).join(",")})`;
+  const signature = generateSig(name, inputs);
   if (existingCoinMachineSigs.indexOf(signature) === -1) {
     neededCoinMachineAbis.push(abiEntry);
   }
 });
 
-console.log('Adding following Coin Machine abis')
+console.log('ADDING following Coin Machine abis')
 console.log(neededCoinMachineAbis)
 
 writeFileSync(COINMACHINE_PATH, JSON.stringify({


### PR DESCRIPTION
What it says on the tin, this PR refactors the (now old) `append_abis` script into `update_abis` which now also has the ability to remove arbitrary abi items (events or functions), other than just adding them.

This is done, as with adding, via a `json` file which contains the complete abi artifact object which will then be removed from the final file that gets pass over to the subgraph code generator 

Note that the full abi artifact object is needed as we use to generate function signature out of it as to ensure proper detection